### PR TITLE
Update ESP-IDF and esp-idf-svc versions, add .DS_Store to .gitignore

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,5 +11,5 @@ build-std = ["std", "panic_abort"]
 
 [env]
 MCU = "esp32"
-ESP_IDF_VERSION = "v5.3.2"
+ESP_IDF_VERSION = "v5.4.1"
 ESP_IDF_TOOLS_INSTALL_DIR = "global"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 /Cargo.lock
 cfg.toml
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ experimental = ["esp-idf-svc/experimental"]
 
 [dependencies]
 log = "0.4"
-esp-idf-svc = { version = "0.50", features = [
+esp-idf-svc = { version = "0.51", features = [
     "critical-section",
     "embassy-time-driver",
     "embassy-sync",

--- a/components_esp32.lock
+++ b/components_esp32.lock
@@ -9,7 +9,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.3.2
+    version: 5.4.1
 direct_dependencies:
 - espressif/esp32-camera
 manifest_hash: 2f4bc7979b30b72f079edf6adeff1542535e018e09e1c46870978ab2c5a55a31


### PR DESCRIPTION
Update the ESP-IDF version to v5.4.1 and esp-idf-svc to v0.51. Additionally, add .DS_Store to the .gitignore file to prevent it from being tracked.