### PR TITLE
Revert ESP-IDF version to v5.3.2

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,5 +11,5 @@ build-std = ["std", "panic_abort"]
 
 [env]
 MCU = "esp32"
-ESP_IDF_VERSION = "v5.4.1"
+ESP_IDF_VERSION = "v5.3.2"
 ESP_IDF_TOOLS_INSTALL_DIR = "global"

--- a/components_esp32.lock
+++ b/components_esp32.lock
@@ -9,7 +9,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.4.1
+    version: 5.3.2
 direct_dependencies:
 - espressif/esp32-camera
 manifest_hash: 2f4bc7979b30b72f079edf6adeff1542535e018e09e1c46870978ab2c5a55a31


### PR DESCRIPTION
Revert the ESP-IDF version from v5.4.1 to v5.3.2 in the configuration files to ensure compatibility with existing dependencies.